### PR TITLE
Export library sounds

### DIFF
--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -38,7 +38,7 @@
                 selectedItem.exportToFile(destination);
             }
         }
-        else
+        else if (selectedItem.itemType !== "folder")
             fl.trace(selectedItem + " is not a sound.");
     }
 }

--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -16,11 +16,8 @@
     
     var folder = fl.browseForFolderURL("Choose an output directory.");
     if (!folder)
-    {
-        alert("Invalid path.");
         return;
-    }
-    
+
     for (var i = 0, total = selectedItems.length; i < total; i++)
     {
         var selectedItem = selectedItems[i];

--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -33,7 +33,10 @@
             else
                 destination = folder + "/" + selectedItem.name.split("/").pop() + ".wav";
             
-            selectedItem.exportToFile(destination);            
+            if (!selectedItem.exportToFile(destination)) {
+                destination = folder + "/" + selectedItem.name.split("/").pop() + ".mp3";
+                selectedItem.exportToFile(destination);
+            }
         }
         else
             fl.trace(selectedItem + " is not a sound.");

--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -29,7 +29,7 @@
             var extension = selectedItem.name.substr(-4);
             
             if (extensions.indexOf(extension) > -1)
-                destination = folder + "/" + selectedItem.name;
+                destination = folder + "/" + selectedItem.name.split("/").pop();
             else
                 destination = folder + "/" + selectedItem.name.split("/").pop() + ".wav";
             

--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -32,11 +32,22 @@
                 destination = folder + "/" + selectedItem.name.split("/").pop();
             else
                 destination = folder + "/" + selectedItem.name.split("/").pop() + ".wav";
+
+            var logMessage = selectedItem.name + " (type=" + selectedItem.originalCompressionType + ")";
             
-            if (!selectedItem.exportToFile(destination)) {
+            if (selectedItem.exportToFile(destination))
+                logMessage += " -> OK";
+            else
+            {
+                logMessage += " -> WAV export failed. Retrying " + selectedItem.name + " as MP3";
                 destination = folder + "/" + selectedItem.name.split("/").pop() + ".mp3";
-                selectedItem.exportToFile(destination);
+                if (selectedItem.exportToFile(destination))
+                    logMessage += " -> OK";
+                else
+                    logMessage += " -> failed";
             }
+            
+            fl.trace(logMessage);
         }
         else if (selectedItem.itemType !== "folder")
             fl.trace(selectedItem + " is not a sound.");

--- a/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
+++ b/animate cc/jsfl/export_library_sounds/Export Library Sounds.jsfl
@@ -1,50 +1,45 @@
 ﻿function exportLibrarySoundsToFiles()
 {
     var doc = fl.getDocumentDOM();
-    var selectedItems;
-    var folder;
-	
     if (!doc)
-	{
-		alert("Open up a FLA first");
-		return;
-	}        
-	
-    selectedItems = doc.library.getSelectedItems();
-	
-	if (!selectedItems || selectedItems.length === 0)
-	{
-		alert("Please select at least one Library sound.");
-		return;
-	}
-	
-    folder = fl.browseForFolderURL("Choose an output directory.");
-	
+    {
+        alert("Open up a FLA first");
+        return;
+    }
+    
+    var selectedItems = doc.library.getSelectedItems();
+    if (!selectedItems || selectedItems.length === 0)
+    {
+        alert("Please select at least one Library sound.");
+        return;
+    }
+    
+    var folder = fl.browseForFolderURL("Choose an output directory.");
     if (!folder)
-	{
-		alert("Invalid path.");
-		return;
-	}        
-	
+    {
+        alert("Invalid path.");
+        return;
+    }
+    
     for (var i = 0, total = selectedItems.length; i < total; i++)
     {
-		var selectedItem = selectedItems[i];
-		
+        var selectedItem = selectedItems[i];
+        
         if (selectedItem.itemType === "sound")
-        {           
+        {
             var destination;
             var extensions = [".aif", ".aiff", ".aifc", ".wav", ".mp3", ".asnd", ".au", ".snd", ".sd2", ".ogg", ".oga", ".flac"];
             var extension = selectedItem.name.substr(-4);
-			
+            
             if (extensions.indexOf(extension) > -1)
                 destination = folder + "/" + selectedItem.name;
             else
                 destination = folder + "/" + selectedItem.name.split("/").pop() + ".wav";
-			
-            selectedItem.exportToFile(destination);			
+            
+            selectedItem.exportToFile(destination);            
         }
-		else
-			fl.trace(selectedItem + " is not a sound.");
+        else
+            fl.trace(selectedItem + " is not a sound.");
     }
 }
 


### PR DESCRIPTION
Made a few changes to the export library sounds jsfl. I wanted to address two items I encountered:

1. Audio encoded as MP3 would fail
According to the JSFL documenation:
> [this method] exports the specified item to a WAV or MP3 file. Export settings are based on the item being exported. When exporting sound items, you should check if the soundItem.originalCompressionType property is equal to"RAW." If this check is false, you can only export the file as MP3. (Optionally, you can try exporting as a WAV file, and if the function returns false, then try to export to MP3.)

So, I added a check was added to the first call to exportToFile, which exports as a wav. If it fails, retry the same export as MP3.

2. Added tracing while the process is going. A message is created for each selected sound item that the code attempts to export.
